### PR TITLE
Chapter 6 exercises, typo fixed

### DIFF
--- a/src/ch06/exercises.ts
+++ b/src/ch06/exercises.ts
@@ -66,7 +66,7 @@ Is {a: {b: [string]}} assignable to {a: {b: [number | string]}}? Yes, if:
 
 // 1i. (a: number) => string and (b: number) => string
 
-let i: (b: number) => string
+let i: (a: number) => string
 i = ((b: number) => 'c') as (b: number) => string
 
 /* Yes. For a function to be assignable to another function, each of its parameters should be >: the other function's parameters, and its return type should be <: the other function's return type. number is >: number, and string is <: string, so the function type is assignable. */


### PR DESCRIPTION
Hi @bcherny thanks for your awesome book. I made this small change, since the exercises says `(a: number) => string and (b: number) => string`, so I'd expect the `i` function of being of type `(a: number) => string`.